### PR TITLE
Basic認証実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,11 +1,15 @@
 class ApplicationController < ActionController::Base
-  before_action :basic_auth
+  before_action :basic_auth, if: :production?
 
   private
 
+  def production?
+    Rails.env.production?
+  end
+
   def basic_auth
     authenticate_or_request_with_http_basic do |username, password|
-      username == '64aa' && password == '1234'
+      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,11 @@
 class ApplicationController < ActionController::Base
+  before_action :basic_auth
+
+  private
+
+  def basic_auth
+    authenticate_or_request_with_http_basic do |username, password|
+      username == '64aa' && password == '1234'
+    end
+  end
 end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -6,6 +6,9 @@ lock '3.12.0'
 set :application, 'freemarket_sample_64a'
 set :linked_files, %w{ config/secrets.yml }
 
+set :rails_env, "production"
+set :unicorn_rack_env, "production"
+
 # どのリポジトリからアプリをpullするかを指定する
 set :repo_url,  'git@github.com:takayasakaguchi/freemarket_sample_64a.git'
 


### PR DESCRIPTION
# why
安全性を高めるため

# what
basic認証の実装
 authenticate_or_request_with_http_basicメソッドを使って実装を行なった
本番環境でのみ認証を行う実装をした