### PR TITLE
トップページ商品画像view修正

### DIFF
--- a/app/assets/stylesheets/toppage.scss
+++ b/app/assets/stylesheets/toppage.scss
@@ -659,8 +659,7 @@ h2 {
     bottom: 0;
     z-index: auto;
     height: 100%;
-    width: 100%;
-    object-fit: cover;
+    width: 175px;
   }
 }
 .productList--img_sold_out {
@@ -678,8 +677,7 @@ h2 {
     width: 100%;
     z-index: auto;
     height: 100%;
-    width: 100%;
-    object-fit: cover;
+    width: 175px;
   }
 }
 


### PR DESCRIPTION
＃Why
トップページの商品写真を綺麗に表示するため。

＃What
・object-fit: cover;を削除
　　等倍で画像を表示するため。
　　現在引き伸ばされて表示されています。
・widthを175pxに固定
　　インターネットエクスプローラーからサイトを閲覧した時にview崩れするため。
　　Google Chromeから閲覧する際には影響はありません。